### PR TITLE
bootstrap: Fix exit status when using override config

### DIFF
--- a/bootstrap.janet
+++ b/bootstrap.janet
@@ -36,7 +36,7 @@
 
 (when-let [override-config (get (dyn :args) 1)]
   (do-bootstrap override-config)
-  (os/exit 1))
+  (os/exit 0))
 
 (print)
 (print "destdir: " destdir)


### PR DESCRIPTION
I want to package jpm for FreeBSD Ports and ran into an issue: I'm running `janet bootstrap.janet configs/bsd_config.janet` and it fails with exit status 1 even though everything was installed with no error and appears to be functional. I think this is just a typo.