### PR TITLE
Correct environment variable order in jpm install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Generally, you will want to install to the same directory that Janet was install
 required headers and libraries for compiling C libraries.
 
 ```
-$ PREFIX=/usr sudo janet bootstrap.janet
+$ sudo PREFIX=/usr janet bootstrap.janet
 ```
 
 ## Updating


### PR DESCRIPTION
- sudo does not respect environment variables set prior to invocation,
switch order in README example