### PR TITLE
Trim git output

### DIFF
--- a/jpm/shutil.janet
+++ b/jpm/shutil.janet
@@ -121,7 +121,7 @@
   (def buf @"")
   (ev/spawn (:read out :all buf))
   (:wait proc)
-  (string/trim buf))
+  (string/trimr buf))
 
 (defn copy
   "Copy a file or directory recursively from one location to another."

--- a/jpm/shutil.janet
+++ b/jpm/shutil.janet
@@ -109,7 +109,7 @@
     (os/execute args :epx env)))
 
 (defn exec-slurp
-  "Read stdout of subprocess and return it in a buffer."
+  "Read stdout of subprocess and return it trimmed in a string."
   [& args]
   (when (dyn :verbose)
     (flush)
@@ -121,7 +121,7 @@
   (def buf @"")
   (ev/spawn (:read out :all buf))
   (:wait proc)
-  buf)
+  (string/trim buf))
 
 (defn copy
   "Copy a file or directory recursively from one location to another."


### PR DESCRIPTION
Solves #25

```
fatal: credential url cannot be parsed: https://github.com/janet-lang/spork.git
```

is actually output from https://github.com/git/git/blob/106298f7f9cca4158a980de149ef217751e1f943/credential.c#L512 which apparently tries to retrieve credentials upon seeing newline.