### PR TITLE
Don't require tags for inclusion in lockfile

### DIFF
--- a/jpm/pm.janet
+++ b/jpm/pm.janet
@@ -206,7 +206,7 @@
   (def mdir (find-manifest-dir))
   (each man (os/dir mdir)
     (def package (parse (slurp (string mdir "/"  man))))
-    (if (and (dictionary? package) (or (package :url) (package :repo)) (package :tag))
+    (if (and (dictionary? package) (or (package :url) (package :repo)))
       (array/push packages package)
       (print "Cannot add local or malformed package " mdir "/" man " to lockfile, skipping...")))
   # Put in correct order, such that a package is preceded by all of its dependencies


### PR DESCRIPTION
Currently `jpm` can prevent some dependencies from being included in lockfile, e.g:

```
(declare-project
  :name "project1"
  :description "project1"
  :dependencies [
                 {:url "https://github.com/Jakski/http/archive/20c1787177243c213c0aafd37bf41eb3cfe30c83.tar.gz"
                  :type :tar}])
```

```
$ rm -rf jpm_tree/ lockfile.jdn
$ jpm -l deps
...
$ jpm -l make-lockfile
Cannot add local or malformed package /opt/jpm_tree/lib/.manifests/http.jdn to lockfile, skipping...
created lockfile.jdn
```

Lockfile resulting from above command won't actually install all dependencies with `load-lockfile`. It makes lockfiles useless while working with tar archives, because it's still required to run `jpm deps` in order to get project working.