### PR TITLE
Fix tags and add shallow fetching

### DIFF
--- a/jpm/declare.janet
+++ b/jpm/declare.janet
@@ -270,9 +270,9 @@
         :file (when (string/has-suffix? ".janet" ndir)
                 (print "running " ndir " ...")
                 (flush)
-                (def result (os/execute 
+                (def result (os/execute
                               [(dyn:janet) "-e" monkey-patch ndir]
-                              :ep 
+                              :ep
                               environ))
                 (when (not= 0 result)
                   (++ errors-found)
@@ -315,6 +315,8 @@
         (case bundle-type
           :git
           (do
+            (if-let [shallow (dyn :shallow)]
+              (put man :shallow shallow))
             (if-let [x (exec-slurp (dyn:gitpath) "remote" "get-url" "origin")]
               (put man :url (if-not (empty? x) x)))
             (if-let [x (exec-slurp (dyn:gitpath) "rev-parse" "HEAD")]


### PR DESCRIPTION
* `(git "clone" url bundle-dir "--single-branch" "-b" tag)` would break on loading lockfile, since lockfiles contain hashes instead of branch names, e.g. `fatal: Remote branch <hash> not found in upstream origin`
* When using `-C` with Git, `--work-tree` and  `--git-dir` are redundant, unless non-standard repository layout is desired. https://git-scm.com/docs/git#Documentation/git.txt--Cltpathgt
* Shallow fetch saves bandwidth and downloads only actually needed content. Yet it's not advised to set it as default, because some Git servers don't handle fetching objects by arbitrary hash. I had no such problems on GitHub and GitLab, but Source Hut throws `Server does not allow request for unadvertised object <hash>` on attempt to fetch object without ref.