### PR TITLE
Add cgen loader and possibility to embed janet in the cgen template

### DIFF
--- a/jpm/cgen.janet
+++ b/jpm/cgen.janet
@@ -404,13 +404,16 @@
     [& args]
     (print "#" (string/join (map string args) " ")))
 
-  (defn emit-janet [body]
-    (match (protect (match (compile body)
-                      (f (function? f)) (f)
-                      (t (table? t)) (error (t :error))))
-      [true (s (bytes? s))] (print s)
-      [true (t (indexed? t))] (print-ir t)
-      [false err] (error err)))
+  (defn emit-janet [& body]
+    (each form body
+      (match
+        (protect (match
+                   (compile form)
+                   (f (function? f)) (f)
+                   (t (table? t)) (error (t :error))))
+        [true (s (bytes? s))] (print s)
+        [true (t (indexed? t))] (each f t (emit-top f))
+        [false err] (error err))))
 
   (setfn emit-top
     [form]

--- a/jpm/cgen.janet
+++ b/jpm/cgen.janet
@@ -310,10 +310,19 @@
       (prin " = ")
       (emit-expression value true)))
 
+  (defn emit-janet [body]
+    (match (protect (match (compile body)
+                      (f (function? f)) (f)
+                      (t (table? t)) (error (t :error))))
+      [true (s (bytes? s))] (print s)
+      [true (t (indexed? t))] (print-ir t)
+      [false err] (error err)))
+
   (setfn emit-statement
     [form]
     (case (get form 0)
       'def (emit-declaration (form 1) (form 2) (form 3))
+      '$ (emit-janet ;(slice form 1))
       (emit-expression form true)))
 
   # Blocks
@@ -403,14 +412,6 @@
   (defn emit-directive
     [& args]
     (print "#" (string/join (map string args) " ")))
-
-  (defn emit-janet [body]
-    (match (protect (match (compile body)
-                      (f (function? f)) (f)
-                      (t (table? t)) (error (t :error))))
-      [true (s (bytes? s))] (print s)
-      [true (t (indexed? t))] (print-ir t)
-      [false err] (error err)))
 
   (setfn emit-top
     [form]

--- a/jpm/cgen.janet
+++ b/jpm/cgen.janet
@@ -310,19 +310,10 @@
       (prin " = ")
       (emit-expression value true)))
 
-  (defn emit-janet [body]
-    (match (protect (match (compile body)
-                      (f (function? f)) (f)
-                      (t (table? t)) (error (t :error))))
-      [true (s (bytes? s))] (print s)
-      [true (t (indexed? t))] (print-ir t)
-      [false err] (error err)))
-
   (setfn emit-statement
     [form]
     (case (get form 0)
       'def (emit-declaration (form 1) (form 2) (form 3))
-      '$ (emit-janet ;(slice form 1))
       (emit-expression form true)))
 
   # Blocks
@@ -412,6 +403,14 @@
   (defn emit-directive
     [& args]
     (print "#" (string/join (map string args) " ")))
+
+  (defn emit-janet [body]
+    (match (protect (match (compile body)
+                      (f (function? f)) (f)
+                      (t (table? t)) (error (t :error))))
+      [true (s (bytes? s))] (print s)
+      [true (t (indexed? t))] (print-ir t)
+      [false err] (error err)))
 
   (setfn emit-top
     [form]


### PR DESCRIPTION
This PR shows the possibility of using Janet loaders to import the cgen file and render the C source file from the template.

It also adds a new top directive, `$`, which will compile and execute code and print the result into the output file. Implementation restricts the evaluation to one form, but that would be an easy fix, and maybe it is the better way?