### PR TITLE
shutil/copy: convert all path seperators for xcopy

### DIFF
--- a/jpm/shutil.janet
+++ b/jpm/shutil.janet
@@ -134,8 +134,8 @@
     (let [end (last (peg/match path-splitter src))
           isdir (= (os/stat src :mode) :directory)]
       (shell "C:\\Windows\\System32\\xcopy.exe"
-             (string/replace "/" "\\" src)
-             (string/replace "/" "\\" (if isdir (string dest "\\" end) dest))
+             (string/replace-all "/" "\\" src)
+             (string/replace-all "/" "\\" (if isdir (string dest "\\" end) dest))
              "/y" "/s" "/e" "/i"))
     (shell "cp" "-rf" src dest)))
 


### PR DESCRIPTION
The `shutil/copy` method converts `/` to `\\` with `(string/replace)` but that function only replaces the first instance of the pattern.
So if a path with multiple `/`s was passed to `shutil/copy` on windows `xcopy.exe` would fail.

This is PR just changes `string/replace` -> `string/replace-all`