### PR TITLE
commands/set-tree: checks if on windows, if so use \ instead of /

### DIFF
--- a/jpm/commands.janet
+++ b/jpm/commands.janet
@@ -213,9 +213,10 @@
   uses the system libraries and headers for janet."
   [tree]
   (def abs-tree (abspath tree))
-  (def tree-bin (string abs-tree "/bin"))
-  (def tree-lib (string abs-tree "/lib"))
-  (def tree-man (string abs-tree "/man"))
+  (def sep (if (is-win) "\\" "/"))
+  (def tree-bin (string abs-tree sep "bin"))
+  (def tree-lib (string abs-tree sep "lib"))
+  (def tree-man (string abs-tree sep "man"))
   (os/mkdir abs-tree)
   (os/mkdir tree-bin)
   (os/mkdir tree-lib)


### PR DESCRIPTION
On windows using `jpm -l deps` I got errors about "Invalid switch /i". After investigation I found that `set-tree` didn't take windows into account, so I amended that. Now I am able to use `jpm -l`. :)