### PR TITLE
Add chance to emit just one block from janet-emit

### DIFF
--- a/jpm/cgen.janet
+++ b/jpm/cgen.janet
@@ -360,7 +360,9 @@
                     (compile form)
                     (f (function? f)) (f)
                     (t (table? t)) (error (t :error))))]
+        [true [true (t (tuple? t) (symbol? (first t)))]] (emit-block t true)
         [true [true (t (indexed? t))]] (each f t (emit-block f true))
+        [false [true (t (tuple? t) (symbol? (first t)))]] (emit-top t)
         [false [true (t (indexed? t))]] (each f t (emit-top f))
         [_ [true (s (bytes? s))]] (print s)
         [_ [false err]] (error err))))


### PR DESCRIPTION
This commit is the last part of cgen improvements on the side of the emitting code with the help of Janet. It adds the option where a tuple with the first member of type `symbol` cgen emits as one block.

I guess that would be it on this front. If you agree, I would like to add documentation for the `.cgen` usage with jpm.