### PR TITLE
Add forward function declaration with empty body

### DIFF
--- a/jpm/cgen.janet
+++ b/jpm/cgen.janet
@@ -407,7 +407,7 @@
     (if (empty? body)
       (print ";")
       (do
-        (print " ")
+        (prin " ")
         (emit-do body))))
 
   (defn emit-directive

--- a/jpm/cgen.janet
+++ b/jpm/cgen.janet
@@ -403,8 +403,12 @@
       (set is-first false)
       (emit-type (arg 1))
       (prin " " (arg 0)))
-    (prin ") ")
-    (emit-do body))
+    (prin ")")
+    (if (empty? body)
+      (print ";")
+      (do
+        (print " ")
+        (emit-do body))))
 
   (defn emit-directive
     [args]


### PR DESCRIPTION
I promised to keep the noise down with `cgen`, but the chance to emit forward fn definition is too good to pass. I hope you agree.