### PR TITLE
Address #63 Add main function to new-project output

### DIFF
--- a/jpm/scaffold.janet
+++ b/jpm/scaffold.janet
@@ -142,6 +142,10 @@
     `Evaluates to "Hello!"`
     []
     "Hello!")
+
+  (defn main
+    [& args]
+    (print (hello)))
   ```)
 
 (deftemplate test-template


### PR DESCRIPTION
This PR attempts to address #63 by adding a `main` function to `init-template`.