### PR TITLE
added :objects option to declare-native

### DIFF
--- a/jpm/declare.janet
+++ b/jpm/declare.janet
@@ -79,6 +79,8 @@
         (do (compile-c :c++ opts src op)
           (set has-cpp true)))
       op))
+  
+  (array/concat objects (get opts :objects []))
 
   (when-let [embedded (opts :embedded)]
     (loop [src :in embedded]


### PR DESCRIPTION
I wanted to ask if something like this makes sense, because it allows a project file like this: https://github.com/saikyun/freja-jaylib/blob/test-deps/project.janet

The main idea is that I can have raylib be compiled, and added as a dependency to (freja-)jaylib. This way people won't have to recompile raylib each time jaylib is modified.

Only missing thing in jpm is linking the .a-file, so I added the `:objects`-key.

I've only tried on macOS, but should work for linux. For the sake of windows, perhaps `declare-native` / `:objects` should deal with using the right suffix. I'm also guessing that for static builds the extra `:objects` would be needed as well.

What do you think @bakpakin? :) Should I continue in this direction, and make sure it works on windows & with static builds as well, or is there a better way to do this?