### PR TITLE
Add tasks subcommand

### DIFF
--- a/jpm/commands.janet
+++ b/jpm/commands.janet
@@ -243,6 +243,15 @@
   (def ks (sort (seq [k :keys (dyn :rules)] k)))
   (each k ks (print k)))
 
+(defn list-tasks
+  [&opt ctx]
+  (import-rules "./project.janet")
+  (def ts
+    (sort (seq [[t r] :pairs (dyn :rules)
+                :when (get r :task)]
+            t)))
+  (each t ts (print t)))
+
 (defn list-installed
   []
   (def xs
@@ -359,6 +368,7 @@
    "repl" run-repl
    "run" local-rule
    "rules" list-rules
+   "tasks" list-tasks
    "update-pkgs" update-pkgs
    "update-installed" update-installed
    "uninstall" uninstall-cmd


### PR DESCRIPTION
This PR adds a `tasks` subcommand so that only rules that are tasks can be listed.

An example where this makes a difference can be seen by trying it in andrewchambers' [janet-where-defined](https://github.com/andrewchambers/janet-where-defined).

With `jpm rules`, I get:
```
$ jpm rules
/home/user/.local/lib/janet/.manifests/where-defined.jdn
build
build/_jmod_where_defined.a
build/_jmod_where_defined.meta.janet
build/_jmod_where_defined.so
build/where-defined.o
build/where-defined.static.o
clean
install
libbacktrace/.libs/libbacktrace.a
manifest
test
uninstall
```
With `jpm tasks`, I get:
```
$ jpm tasks
build
clean
install
manifest
test
uninstall
```

This can also be handy when putting together shell completion functionality as `jpm` can be queried for a list of rules that are tasks.
