### PR TITLE
Add create-dirs before codegen

### DIFF
--- a/jpm/declare.janet
+++ b/jpm/declare.janet
@@ -85,6 +85,7 @@
       (case suffix
         ".c" (compile-c :cc opts src op)
         ".janet" (do
+                   (create-dirs op)
                    (def csrc (out-path src suffix ".c"))
                    (rule csrc [src] (dofile-codegen src csrc))
                    (compile-c :cc opts csrc op))


### PR DESCRIPTION
Without this fix first `jpm build` for projects with declared native from Janet code errors with:

`error: failed to open file build/src.c: No such file or directory.`