### PR TITLE
Make :source refer to existing directory

### DIFF
--- a/jpm/scaffold.janet
+++ b/jpm/scaffold.janet
@@ -48,7 +48,7 @@
 
   (declare-source
     :prefix "$name"
-    :source ["src/init.janet"])
+    :source ["$name/init.janet"])
   ````)
 
 (deftemplate native-project-template


### PR DESCRIPTION
This PR attempts to address a remark made in [a discussion](https://github.com/janet-lang/janet/discussions/1054#discussioncomment-6051809) at the janet repository:

> Note: In the project.janet file in declare-executable you have to refer to the init.janet file with the folder name example/init.janet, whereas in declare-source you need to refer to src/init.janet.

I guess there is more than one way to address this including:

* Change the name of the source directory that is created
* Change the associated value for `:source` in `project.janet`

This PR took the latter path.
