### PR TITLE
Address #74 - add new-exe-project subcommand

### DIFF
--- a/jpm/commands.janet
+++ b/jpm/commands.janet
@@ -52,6 +52,9 @@
         new-c-project name
             Create a new C+Janet project in a directory `name`.
 
+        new-exe-project name
+            Create a new project for an executable in a directory `name`.
+
     Privileged global subcommands:
 
         install (repo or name)...
@@ -349,6 +352,11 @@
   [name]
   (scaffold-project name {:c true}))
 
+(defn new-exe-project
+  "Create a new executable project"
+  [name]
+  (scaffold-project name {:c false :exe true}))
+
 (def subcommands
   {"build" build
    "clean" clean
@@ -378,5 +386,6 @@
    "exec" shell
    "new-project" new-project
    "new-c-project" new-c-project
+   "new-exe-project" new-exe-project
    "janet" (fn [& args] (shell (dyn :executable) ;args))
    "save-config" save-config})

--- a/jpm/scaffold.janet
+++ b/jpm/scaffold.janet
@@ -96,6 +96,18 @@
   }
   ```)
 
+(deftemplate exe-project-template
+  ````
+  (declare-project
+    :name "$name"
+    :description ```$description ```
+    :version "0.0.0")
+
+  (declare-executable
+    :name "$name"
+    :entry "$name/init.janet")
+  ````)
+
 (deftemplate readme-template
   ```
   # ${name}
@@ -176,6 +188,7 @@
   (def description (opt-ask :description options))
   (def date (format-date))
   (def scaffold-native (get options :c))
+  (def scaffold-exe (get options :exe))
   (def template-opts (merge-into @{:name name :year year :author author :date date :description description} options))
   (print "creating project directory for " name)
   (os/mkdir name)
@@ -187,11 +200,15 @@
   (spit (string name "/README.md") (readme-template template-opts))
   (spit (string name "/LICENSE") (license-template template-opts))
   (spit (string name "/CHANGELOG.md") (changelog-template template-opts))
-  (if scaffold-native
+  (cond
+    scaffold-native
     (do
       (os/mkdir (string name "/c"))
       (spit (string name "/c/module.c") (module-c-template template-opts))
       (spit (string name "/test/native.janet") (native-test-template template-opts))
       (spit (string name "/project.janet") (native-project-template template-opts)))
+    scaffold-exe
+    (do
+      (spit (string name "/project.janet") (exe-project-template template-opts)))
     (do
       (spit (string name "/project.janet") (project-template template-opts)))))


### PR DESCRIPTION
This PR is an attempt to address #74 by adding a `new-exe-project` subcommand.

It includes changes to `jpm/scaffold.janet` and `jpm/commands.janet`.

`jpm/scaffold.janet`:

* Addition of a new template named `exe-project-template`
* Change the logic a bit in `scaffold-project` to accomodate the new template

`jpm/commands.janet`:

* Modify the usage string in `help` to mention the new subcommand
* Addition of a `new-exe-project` function that invokes `scaffold/scaffold-project` appropriately
* Add key-value pair for new subcommand in `subcommands` definition