### PR TITLE
Further address #71 - refine do-monkeypatch

### DIFF
--- a/jpm/shutil.janet
+++ b/jpm/shutil.janet
@@ -231,7 +231,7 @@
   [build-dir]
   (def old-builddir (dyn :build-dir))
   (put root-env :build-dir build-dir)
-  (array/insert module/paths 1 [build-dir :native check-is-dep])
+  (array/insert module/paths 1 [(string build-dir ":all::native:") :native check-is-dep])
   old-builddir)
 
 (defn undo-monkeypatch


### PR DESCRIPTION
This PR contains a refinement of work @tionis and I did for #71.

It includes one change to `do-monkeypatch`, specifically a tweak to the template path used:

```janet
(string build-dir ":all::native:")
```

instead of `build-dir`.

Please see [the discussion from here](https://github.com/janet-lang/jpm/issues/71#issuecomment-1581017161) for some details.  Note that the change included in this PR is slightly different (better I think), but I also tested it and got comarable good results.
