### PR TITLE
Raise error if update-installed fails

### DIFF
--- a/jpm/pm.janet
+++ b/jpm/pm.janet
@@ -325,7 +325,9 @@
         (++ updated-count))
       ([err f]
        (debug/stacktrace f err (string "unable to update dependency " p ": ")))))
-  (print "updated " updated-count " of " (length to-update) " installed packages"))
+  (print "updated " updated-count " of " (length to-update) " installed packages")
+  (unless (= updated-count (length to-update))
+    (error "could not update all installed packages")))
 
 (defn out-of-tree-config
   "Create an out of tree build configuration. This lets a user have a debug or release build, as well


### PR DESCRIPTION
The `update-installed` function catches all errors raised during package updates. As a result, running `jpm update-install` will result in a zero exit code even if an error occurred. This PR continues catching these errors but then raises an error before the function returns.

## Discussion

Currently, the `update-installed` function catches errors that are raised by `bundle-install`. This ensures that no one failure prevents other packages from being updated. However, while `update-installed` does print stacktraces for these errors, it does not provide any indication to the calling function that errors occurred. As noted above, this means that when called from the command line with `jpm update-installed` the command returns a zero exit code.

## Alternatives

Rather than raise an error, the function could return a value (e.g. `:error`) that would be checked by the `cli/main` function. A quick review of other functions suggested that only `update-installed` would use this technique as other functions simply raise an error. Following a consistent approach was considered preferable.