### PR TITLE
Added colored output to jpm test is (os/isatty)

### DIFF
--- a/jpm/declare.janet
+++ b/jpm/declare.janet
@@ -298,13 +298,15 @@
                 (def result (run-script ndir))
                 (when (not= 0 result)
                   (++ errors-found)
-                  (eprintf "non-zero exit code in %s: %d" ndir result)))
+                  (eprinf (color :red "non-zero exit code in %s: ") ndir)
+                  (eprintf "%d" result)))
         :directory (dodir ndir))))
   (dodir (or root-directory "test"))
   (if (zero? errors-found)
-    (print "All tests passed.")
+    (print (color :green "✓ All tests passed."))
     (do
-      (printf "Failing test scripts: %d" errors-found)
+      (prin (color :red "✘ Failing test scripts: "))
+      (printf "%d" errors-found)
       (os/exit 1)))
   (flush))
 

--- a/jpm/shutil.janet
+++ b/jpm/shutil.janet
@@ -4,6 +4,17 @@
 
 (use ./config)
 
+(def colors
+  {:green "\e[32m"
+   :red "\e[31m"})
+
+(defn color
+  "Color text with ascii escape sequences if (os/isatty)"
+  [input-color text]
+  (if (os/isatty)
+    (string (get colors input-color "\e[0m") text "\e[0m")
+    text))
+
 (defn is-win
   "Check if we should assume a DOS-like shell or default
   to posix shell."


### PR DESCRIPTION
Pretty simple addition. I found the output of jpm test a bit hard to parse at a glance so I added some color if the output is a tty.