### PR TITLE
developing a native module: linking against spork/tarray didnt work on windows

### DIFF
--- a/jpm/cc.janet
+++ b/jpm/cc.janet
@@ -98,22 +98,6 @@
           (clexe-shell cc ;defines "/c" ;cflags (string "/Fo" dest) src)
           (shell cc "-c" src ;defines ;cflags "-o" dest))))
 
-  (comment
-
-    (def dep-ldflags (seq [x :in deplibs] (string (dyn:modpath) "/" x (dyn:modext)))) # original behaviour when building wjpu with tarray as a dependency: \spork\tarray.dll : fatal error LNK1107: invalid or corrupt file: cannot read at 0x2D0
-    (seq [x :in deplibs] (string (dyn:modpath) "/" x ".lib")) # see above for original behaviour; using :importlibext works for wjpu + tarray:
-see https://stackoverflow.com/questions/9688200/difference-between-shared-objects-so-static-libraries-a-and-dlls-so
-   ```
-When a developer wants to use an already-built DLL, she must either reference
-an "export library" (*.LIB) created by the DLL developer when she created the
-DLL, or she must explicitly load the DLL at run time and request the entry
-point address by name via the LoadLibrary() and GetProcAddress() mechanisms.
-Most of the time, linking against a LIB file (which simply contains the linker
-metadata for the DLL's exported entry points) is the way DLLs get used. Dynamic
-loading is reserved typically for implementing "polymorphism" or "runtime
-configurability" in program behaviors (accessing add-ons or later-defined
-functionality, aka "plugins").```)
-
 (defn link-c
   "Link C or C++ object files together to make a native module."
   [has-cpp opts target & objects]
@@ -122,9 +106,10 @@ functionality, aka "plugins").```)
   (def lflags [;(opt opts :lflags)
                ;(if (opts :static) [] (dyn:dynamic-lflags))])
   (def deplibs (get opts :native-deps []))
-  (def linkext (if (is-win-or-mingw)
-                    (dyn :importlibext)
-                    (dyn :modext)))
+  (def linkext
+    (if (is-win-or-mingw)
+      (dyn :importlibext)
+      (dyn :modext)))
   (def dep-ldflags (seq [x :in deplibs] (string (dyn:modpath) "/" x linkext)))
   # Use import libs on windows - we need an import lib to link natives to other natives.
   (def dep-importlibs

--- a/jpm/cc.janet
+++ b/jpm/cc.janet
@@ -98,6 +98,22 @@
           (clexe-shell cc ;defines "/c" ;cflags (string "/Fo" dest) src)
           (shell cc "-c" src ;defines ;cflags "-o" dest))))
 
+  (comment
+
+    (def dep-ldflags (seq [x :in deplibs] (string (dyn:modpath) "/" x (dyn:modext)))) # original behaviour when building wjpu with tarray as a dependency: \spork\tarray.dll : fatal error LNK1107: invalid or corrupt file: cannot read at 0x2D0
+    (seq [x :in deplibs] (string (dyn:modpath) "/" x ".lib")) # see above for original behaviour; using :importlibext works for wjpu + tarray:
+see https://stackoverflow.com/questions/9688200/difference-between-shared-objects-so-static-libraries-a-and-dlls-so
+   ```
+When a developer wants to use an already-built DLL, she must either reference
+an "export library" (*.LIB) created by the DLL developer when she created the
+DLL, or she must explicitly load the DLL at run time and request the entry
+point address by name via the LoadLibrary() and GetProcAddress() mechanisms.
+Most of the time, linking against a LIB file (which simply contains the linker
+metadata for the DLL's exported entry points) is the way DLLs get used. Dynamic
+loading is reserved typically for implementing "polymorphism" or "runtime
+configurability" in program behaviors (accessing add-ons or later-defined
+functionality, aka "plugins").```)
+
 (defn link-c
   "Link C or C++ object files together to make a native module."
   [has-cpp opts target & objects]
@@ -106,11 +122,14 @@
   (def lflags [;(opt opts :lflags)
                ;(if (opts :static) [] (dyn:dynamic-lflags))])
   (def deplibs (get opts :native-deps []))
-  (def dep-ldflags (seq [x :in deplibs] (string (dyn:modpath) "/" x (dyn:modext))))
+  (def linkext (if (is-win-or-mingw)
+                    (dyn :importlibext)
+                    (dyn :modext)))
+  (def dep-ldflags (seq [x :in deplibs] (string (dyn:modpath) "/" x linkext)))
   # Use import libs on windows - we need an import lib to link natives to other natives.
   (def dep-importlibs
     (if (is-win-or-mingw)
-      (seq [x :in deplibs] (string (dyn:modpath) "/" x ".lib"))
+      (seq [x :in deplibs] (string (dyn:modpath) "/" x (dyn :importlibext)))
       @[]))
   (when-let [import-lib (dyn :janet-importlib)]
     (array/push dep-importlibs import-lib))

--- a/jpm/declare.janet
+++ b/jpm/declare.janet
@@ -66,6 +66,7 @@
 
   (def modext (dyn:modext))
   (def statext (dyn:statext))
+  (def importlibext (dyn :importlibext nil))
 
   # Make dynamic module
   (def lname (string (find-build-dir) name modext))
@@ -127,6 +128,7 @@
   # Make static module
   (unless (dyn :nostatic)
     (def sname (string (find-build-dir) name statext))
+    (def impname (if importlibext (string (find-build-dir) name importlibext) nil))
     (def opts (merge @{:entry-name ename} opts))
     (def sobjext ".static.o")
     (def sjobjext ".janet.static.o")
@@ -166,6 +168,8 @@
     (when (check-release)
       (add-dep "build" sname))
     (put declare-targets :static sname)
+    (when impname
+      (install-rule impname path))
     (install-rule sname path))
 
   declare-targets)

--- a/jpm/make-config.janet
+++ b/jpm/make-config.janet
@@ -113,6 +113,7 @@
       :nocolor false
       :pkglist pkglist
       :silent false
+      :importlibext (if (shutil/is-win-or-mingw) ".lib" [])
       :statext (if (shutil/is-win-or-mingw) ".static.lib" ".a")
       :tarpath "tar"
       :test false

--- a/jpm/make-config.janet
+++ b/jpm/make-config.janet
@@ -113,7 +113,7 @@
       :nocolor false
       :pkglist pkglist
       :silent false
-      :importlibext (if (shutil/is-win-or-mingw) ".lib" [])
+      :importlibext (if (shutil/is-win-or-mingw) ".lib" nil)
       :statext (if (shutil/is-win-or-mingw) ".static.lib" ".a")
       :tarpath "tar"
       :test false


### PR DESCRIPTION
i noticed problems during linking, this fixed them for me

through trial and error at first i ended up using the .static.lib files during linking, it worked.

but after reading more into linking dynamic libraries on windows, i figured the .lib files are enough to link to a dll