### PR TITLE
allow bundle-install to avoid reinstalling an already installed package

### DIFF
--- a/jpm/commands.janet
+++ b/jpm/commands.janet
@@ -279,7 +279,7 @@
 
 (defn update-pkgs
   []
-  (bundle-install (dyn:pkglist)))
+  (bundle-install (dyn:pkglist)) false true)
 
 (defn quickbin
   [input output]


### PR DESCRIPTION
This pull request enables bundle-install to avoid reinstalling already installed packages, except when explicitly told to via either `jpm update-pkgs` or `jpm update-installed`. This enables `jpm deps` or `jpm load-lockfile` to have essentially zero cost when the packages are already installed.

Related: #82 