### PR TITLE
Partially address #83 by putting dir in manifest

### DIFF
--- a/jpm/declare.janet
+++ b/jpm/declare.janet
@@ -185,7 +185,9 @@
   (if (bytes? sources)
     (install-rule sources path)
     (each s sources
-      (install-rule s path))))
+      (install-rule s path)))
+  (when prefix
+    (array/push (dyn :installed-files) path)))
 
 (defn declare-headers
   "Declare headers for a library installation. Installed headers can be used by other native


### PR DESCRIPTION
### What

This PR is an attempt to partially address #83.

### Problem

It appears that `jpm`'s current uninstallation behavior may not mesh well with how `bundle/*` approaches installation.

When `bundle/*` tries to install, [it will bail if a directory exists already](https://github.com/janet-lang/janet/blob/73b1cf547e7cb74ee94f58cada0e9377af4c095d/src/boot/boot.janet#L4456-L4457), but currently, `jpm` can leave empty directories around after uninstallation (as can be seen via #83).

For some repositories that might be trying to support both `jpm` as well as `bundle/*`-based approaches, this can lead to installation failures.

Please see [this comment](https://github.com/janet-lang/jpm/issues/83#issuecomment-3315877525) for details of a concrete sequence of steps leading to an installation failure, but briefly:

```
# suppose current directory is a clone of some project that supports both `jpm` and `bundle/*`
jpm install
jpm uninstall       # can leave an empty directory
janet --install .   # can error because of left-over directory from previous step
```

### Trigger

The situation can arise via the use of the `:prefix` feature of `declare-source` as can be seen [here](https://github.com/janet-lang/jpm/issues/83#issue-1859507259).

### `:prefix`-Sharing and Some Consequences

I have [investigated use of `declare-source` with `:prefix`](https://github.com/janet-lang/jpm/issues/83#issuecomment-3321729805) across a sizable number of existing repositories and not yet found a case where a common `:prefix` (or a subpath of it) was being used by more than one project [1].  (I'm going to call that kind of use "`:prefix`-sharing" to ease further discussion.)

It also seems to be the case that `:prefix`-sharing is not supported by `bundle/*` (as can be seen from its bailing during installation).  (Support of `:prefix`-sharing would mean that `bundle/*` would be willing to proceed with installation even if a directory already existed.)

Unfortunately, these behaviors of `jpm` and `bundle/*` can [result in problems](https://github.com/janet-lang/jpm/issues/83#issuecomment-3315877525).

It seems clear that there is going to be a period of time when there are people who use both `jpm` and a `bundle/*`-based system (e.g. `janet-pm` or `jeep`) so it doesn't seem like this is a theoretical concern [2].

Thus, it seems better for both `jpm` and `bundle/*`-based systems to behave in a compatible manner (at least for this feature) for consistency and smoother interoperation.  That is, it seems that either both should support `:prefix`-sharing or neither should [3].

### Approach in this PR

This PR assumes that the choice made in `bundle/*` is the desired behavior going forward and hence attempts to restrict / constrain `jpm`'s current behavior by having `jpm uninstall` not leave behind empty directories.

This is accomplished by ensuring the path of the appropriate directory is recorded in the manifest file (it is not ATM).

### Alternative Consideration

An alternative arrangement would be for `bundle/*` to not halt installation if it finds a directory already in place.  That approach was briefly attempted [here](https://github.com/janet-lang/jpm/issues/83#issuecomment-3315894824).  A more full attempt might be to try to avoid overwriting existing files.  

The alternative idea seems more complicated though and it is unclear whether the complexity would be worth it.  Perhaps it is worth examining in more detail though.  Would be happy to hear discussion about these matters.

### Speculation

Perhaps initially `:prefix`-sharing could be forbidden and at a later date, if there is demand, adding it could be considered.

---

[1] Motivation for such use might be for some kind of plug-in system.  It also appears that someone had the idea to share a prefix [here](https://github.com/Techcable/janet-json-pure/blob/34c717fb89c285ce13483c8b30f3ce415c6c7d1b/project.janet#L12-L13) (though it doesn't look like they used it).

[2] Not all existing projects will transition at the same time (in fact some may never) and thus it seems unreasonable to expect folks to switch over to a newer system all at once.

[3] An alternative phrasing is that one of the following two options would result in a more consistent situation:

* `jpm` should not leave behind empty directories as described in #83 

-OR-

* `bundle/install` should permit installation to continue even if a directory exists already

It seems to me that the current situation is less consistent than either of the two aforementioned options.