### PR TITLE
Add bash, fish, and zsh shell completions for jpm and janet

### DIFF
--- a/completions/README.md
+++ b/completions/README.md
@@ -1,0 +1,50 @@
+# Shell completions for jpm and janet
+
+This directory contains shell completion scripts for `jpm` and `janet`.
+
+## jpm
+
+### Bash
+
+```bash
+# User install (no root required)
+cp jpm.bash ~/.local/share/bash-completion/completions/jpm
+# or source directly from ~/.bashrc:
+source /path/to/jpm.bash
+```
+
+### Fish
+
+```fish
+cp jpm.fish ~/.config/fish/completions/jpm.fish
+```
+
+### Zsh
+
+```zsh
+# Place in a directory on your $fpath
+cp jpm.zsh ~/.zsh/completions/_jpm
+# Ensure ~/.zsh/completions is in $fpath in ~/.zshrc:
+# fpath=(~/.zsh/completions $fpath)
+# autoload -Uz compinit && compinit
+```
+
+## janet
+
+### Bash
+
+```bash
+cp janet.bash ~/.local/share/bash-completion/completions/janet
+```
+
+### Fish
+
+```fish
+cp janet.fish ~/.config/fish/completions/janet.fish
+```
+
+### Zsh
+
+```zsh
+cp janet.zsh ~/.zsh/completions/_janet
+```

--- a/completions/janet.bash
+++ b/completions/janet.bash
@@ -1,0 +1,70 @@
+# bash completion for janet (https://github.com/janet-lang/janet)
+# Install: place this file in ~/.local/share/bash-completion/completions/janet
+#          or source it from your ~/.bashrc
+
+_janet_flags=(
+    -h --help
+    -v --version
+    -s --stdin
+    -e --eval
+    -E --expression
+    -d --debug
+    -r --repl
+    -R --noprofile
+    -p --persistent
+    -q --quiet
+    -k --flycheck
+    -m --syspath
+    -c --compile
+    -i --image
+    -n --nocolor
+    -N --color
+    -l --library
+    -w --lint-warn
+    -x --lint-error
+    -b --install
+    -B --reinstall
+    -u --uninstall
+    -U --update-all
+    -P --prune
+    -L --list
+    --
+)
+
+_janet() {
+    local cur prev
+    _init_completion || return
+
+    case "$prev" in
+        -e|--eval|-E|--expression)
+            # Expects a code string — no file completion
+            return
+            ;;
+        -m|--syspath)
+            _filedir -d
+            return
+            ;;
+        -c|--compile|-l|--library|-b|--install)
+            _filedir
+            return
+            ;;
+        -w|--lint-warn|-x|--lint-error)
+            COMPREPLY=( $(compgen -W "none normal strict" -- "$cur") )
+            return
+            ;;
+        -B|--reinstall|-u|--uninstall)
+            # Bundle names — no obvious completion source
+            return
+            ;;
+    esac
+
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "${_janet_flags[*]}" -- "$cur") )
+        return
+    fi
+
+    # Default: complete with janet source files and images
+    _filedir '@(janet|jimage)'
+}
+
+complete -F _janet janet

--- a/completions/janet.fish
+++ b/completions/janet.fish
@@ -1,0 +1,34 @@
+# fish completion for janet (https://github.com/janet-lang/janet)
+# Install: place this file in ~/.config/fish/completions/janet.fish
+
+# Flags that take an argument
+complete -c janet -s e -l eval       -r -d "Execute a string of Janet code"
+complete -c janet -s E -l expression -r -d "Evaluate as short-fn with arguments"
+complete -c janet -s m -l syspath    -r -d "Set system path for loading global modules" -a "(__fish_complete_directories)"
+complete -c janet -s c -l compile    -r -d "Compile source to image" -a "(__fish_complete_suffix .janet)"
+complete -c janet -s l -l library   -r -d "Use a module before processing more arguments"
+complete -c janet -s w -l lint-warn  -r -d "Lint warning level" -a "none normal strict"
+complete -c janet -s x -l lint-error -r -d "Lint error level"   -a "none normal strict"
+complete -c janet -s b -l install    -r -d "Install a bundle from a directory"
+complete -c janet -s B -l reinstall  -r -d "Reinstall a bundle by name"
+complete -c janet -s u -l uninstall  -r -d "Uninstall a bundle by name"
+
+# Boolean flags
+complete -c janet -s h -l help        -d "Show help"
+complete -c janet -s v -l version     -d "Print version"
+complete -c janet -s s -l stdin       -d "Use raw stdin"
+complete -c janet -s d -l debug       -d "Set debug flag in the REPL"
+complete -c janet -s r -l repl        -d "Enter REPL after running scripts"
+complete -c janet -s R -l noprofile   -d "Disable loading profile.janet"
+complete -c janet -s p -l persistent  -d "Keep executing on top-level errors"
+complete -c janet -s q -l quiet       -d "Hide logo"
+complete -c janet -s k -l flycheck    -d "Compile but do not execute"
+complete -c janet -s i -l image       -d "Load script argument as image file"
+complete -c janet -s n -l nocolor     -d "Disable ANSI color in REPL"
+complete -c janet -s N -l color       -d "Enable ANSI color in REPL"
+complete -c janet -s U -l update-all  -d "Reinstall all installed bundles"
+complete -c janet -s P -l prune       -d "Uninstall orphaned bundles"
+complete -c janet -s L -l list        -d "List all installed bundles"
+
+# Default: complete with .janet files and .jimage files
+complete -c janet -a "(__fish_complete_suffix .janet .jimage)" -d "Script"

--- a/completions/janet.zsh
+++ b/completions/janet.zsh
@@ -1,0 +1,37 @@
+#compdef janet
+# zsh completion for janet (https://github.com/janet-lang/janet)
+# Install: place this file in a directory on your $fpath, e.g. ~/.zsh/completions/_janet
+#          then run: autoload -Uz compinit && compinit
+
+_janet() {
+    _arguments \
+        '(-h --help)'{-h,--help}'[Show help]' \
+        '(-v --version)'{-v,--version}'[Print version]' \
+        '(-s --stdin)'{-s,--stdin}'[Use raw stdin]' \
+        '(-e --eval)'{-e,--eval}'[Execute a string of Janet code]:code: ' \
+        '(-E --expression)'{-E,--expression}'[Evaluate as short-fn with arguments]:code: ' \
+        '(-d --debug)'{-d,--debug}'[Set debug flag in the REPL]' \
+        '(-r --repl)'{-r,--repl}'[Enter REPL after running scripts]' \
+        '(-R --noprofile)'{-R,--noprofile}'[Disable loading profile.janet]' \
+        '(-p --persistent)'{-p,--persistent}'[Keep executing on top-level errors]' \
+        '(-q --quiet)'{-q,--quiet}'[Hide logo]' \
+        '(-k --flycheck)'{-k,--flycheck}'[Compile but do not execute]' \
+        '(-m --syspath)'{-m,--syspath}'[Set system path for modules]:syspath:_files -/' \
+        '(-c --compile)'{-c,--compile}'[Compile source to image]:source:_files -g "*.janet"' \
+        '(-i --image)'{-i,--image}'[Load script as image file]' \
+        '(-n --nocolor)'{-n,--nocolor}'[Disable ANSI color in REPL]' \
+        '(-N --color)'{-N,--color}'[Enable ANSI color in REPL]' \
+        '(-l --library)'{-l,--library}'[Use a module before other args]:module:_files' \
+        '(-w --lint-warn)'{-w,--lint-warn}'[Lint warning level]:level:(none normal strict)' \
+        '(-x --lint-error)'{-x,--lint-error}'[Lint error level]:level:(none normal strict)' \
+        '(-b --install)'{-b,--install}'[Install a bundle from directory]:directory:_files -/' \
+        '(-B --reinstall)'{-B,--reinstall}'[Reinstall a bundle by name]:name: ' \
+        '(-u --uninstall)'{-u,--uninstall}'[Uninstall a bundle by name]:name: ' \
+        '(-U --update-all)'{-U,--update-all}'[Reinstall all installed bundles]' \
+        '(-P --prune)'{-P,--prune}'[Uninstall orphaned bundles]' \
+        '(-L --list)'{-L,--list}'[List all installed bundles]' \
+        '--[Stop handling options]' \
+        '*:script:_files -g "*.janet *.jimage"'
+}
+
+_janet "$@"

--- a/completions/jpm.bash
+++ b/completions/jpm.bash
@@ -1,0 +1,113 @@
+# bash completion for jpm (https://github.com/janet-lang/jpm)
+# Install: place this file in ~/.local/share/bash-completion/completions/jpm
+#          or source it from your ~/.bashrc
+
+_jpm_subcommands=(
+    build
+    clean
+    configure
+    clear-cache
+    clear-manifest
+    debug-repl
+    deps
+    exec
+    help
+    install
+    janet
+    list-installed
+    list-pkgs
+    load-lockfile
+    make-lockfile
+    new-c-project
+    new-exe-project
+    new-project
+    quickbin
+    repl
+    rule-tree
+    rules
+    run
+    save-config
+    show-config
+    show-paths
+    tasks
+    test
+    uninstall
+    update-installed
+    update-pkgs
+)
+
+_jpm_global_flags=(
+    --local
+    --tree=
+    --verbose
+    --offline
+    --silent
+    --nocolor
+    --test
+    --update-pkgs
+    --config-file=
+    --modpath=
+    --binpath=
+    --headerpath=
+    --libpath=
+    --optimize=
+    --workers=
+    --build-type=
+)
+
+_jpm() {
+    local cur prev words cword
+    _init_completion || return
+
+    # Complete global flags
+    if [[ "$cur" == --* ]]; then
+        COMPREPLY=( $(compgen -W "${_jpm_global_flags[*]}" -- "$cur") )
+        return
+    fi
+
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-l -v" -- "$cur") )
+        return
+    fi
+
+    # Find if a subcommand has already been given
+    local subcommand=""
+    for word in "${words[@]:1}"; do
+        if [[ "$word" != -* ]]; then
+            subcommand="$word"
+            break
+        fi
+    done
+
+    if [[ -z "$subcommand" || "$cur" == "$subcommand" ]]; then
+        COMPREPLY=( $(compgen -W "${_jpm_subcommands[*]}" -- "$cur") )
+        return
+    fi
+
+    # Subcommand-specific completions
+    case "$subcommand" in
+        install)
+            # Repo URLs or package names; fall back to file completion
+            _filedir
+            ;;
+        run|rule-tree)
+            # Complete with rules from project if available
+            if command -v jpm &>/dev/null; then
+                local rules
+                rules=$(jpm rules 2>/dev/null | awk '{print $1}')
+                COMPREPLY=( $(compgen -W "$rules" -- "$cur") )
+            fi
+            ;;
+        load-lockfile|make-lockfile|config-file)
+            _filedir '*.jdn'
+            ;;
+        new-project|new-c-project|new-exe-project|quickbin)
+            # Expects a name/path argument
+            _filedir -d
+            ;;
+        *)
+            ;;
+    esac
+}
+
+complete -F _jpm jpm

--- a/completions/jpm.fish
+++ b/completions/jpm.fish
@@ -1,0 +1,72 @@
+# fish completion for jpm (https://github.com/janet-lang/jpm)
+# Install: place this file in ~/.config/fish/completions/jpm.fish
+
+# Subcommands
+set -l subcommands \
+    "build\tBuild the current project" \
+    "clean\tRemove build artifacts" \
+    "configure\tConfigure build settings" \
+    "clear-cache\tClear the git package cache" \
+    "clear-manifest\tClear the install manifest" \
+    "debug-repl\tStart a debug REPL" \
+    "deps\tInstall project dependencies" \
+    "exec\tRun a command with JANET_PATH set" \
+    "help\tShow help text" \
+    "install\tInstall the current project or a package" \
+    "janet\tRun janet with JANET_PATH set" \
+    "list-installed\tList installed packages" \
+    "list-pkgs\tList available packages" \
+    "load-lockfile\tInstall from a lockfile" \
+    "make-lockfile\tCreate a lockfile" \
+    "new-c-project\tScaffold a new C+Janet project" \
+    "new-exe-project\tScaffold a new executable project" \
+    "new-project\tScaffold a new Janet project" \
+    "quickbin\tCreate a standalone executable from a script" \
+    "repl\tStart a REPL with project env" \
+    "rule-tree\tShow the build rule dependency tree" \
+    "rules\tList all build rules" \
+    "run\tRun a specific build rule" \
+    "save-config\tSave current config to a file" \
+    "show-config\tPrint current configuration" \
+    "show-paths\tPrint install paths" \
+    "tasks\tList defined project tasks" \
+    "test\tRun project tests" \
+    "uninstall\tUninstall the current project or a package" \
+    "update-installed\tReinstall all installed packages" \
+    "update-pkgs\tUpdate the package listing"
+
+# Only offer subcommands when none has been given yet
+function __jpm_no_subcommand
+    for word in (commandline -opc)
+        if contains -- $word build clean configure clear-cache clear-manifest \
+                debug-repl deps exec help install janet list-installed list-pkgs \
+                load-lockfile make-lockfile new-c-project new-exe-project new-project \
+                quickbin repl rule-tree rules run save-config show-config show-paths \
+                tasks test uninstall update-installed update-pkgs
+            return 1
+        end
+    end
+    return 0
+end
+
+complete -c jpm -f -n __jpm_no_subcommand -a $subcommands
+
+# Global flags
+complete -c jpm -l local       -s l -d "Use local tree ./jpm_tree"
+complete -c jpm -l verbose     -s v -d "Show verbose output"
+complete -c jpm -l offline          -d "Do not download remote repositories"
+complete -c jpm -l silent           -d "Suppress subprocess output"
+complete -c jpm -l nocolor          -d "Disable color in debug REPL"
+complete -c jpm -l test             -d "Enable testing when installing"
+complete -c jpm -l update-pkgs      -d "Update package listing before running"
+complete -c jpm -l tree        -r   -d "Use a custom tree directory"
+complete -c jpm -l config-file -r   -d "Load settings from this config file"
+complete -c jpm -l modpath     -r   -d "Module installation directory"
+complete -c jpm -l binpath     -r   -d "Binary installation directory"
+complete -c jpm -l headerpath  -r   -d "Janet headers directory"
+complete -c jpm -l optimize    -r   -d "C/C++ optimization level (0-3)"
+complete -c jpm -l workers     -r   -d "Number of parallel build workers"
+complete -c jpm -l build-type  -r   -d "Build preset: release, debug, or develop"
+
+# Lockfile completions for relevant subcommands
+complete -c jpm -n "__fish_seen_subcommand_from load-lockfile make-lockfile" -a "*.jdn" -d "Lockfile"

--- a/completions/jpm.zsh
+++ b/completions/jpm.zsh
@@ -1,0 +1,95 @@
+#compdef jpm
+# zsh completion for jpm (https://github.com/janet-lang/jpm)
+# Install: place this file in a directory on your $fpath, e.g. ~/.zsh/completions/_jpm
+#          then run: autoload -Uz compinit && compinit
+
+local -a subcommands
+subcommands=(
+    'build:Build the current project'
+    'clean:Remove build artifacts'
+    'configure:Configure build settings'
+    'clear-cache:Clear the git package cache'
+    'clear-manifest:Clear the install manifest'
+    'debug-repl:Start a debug REPL'
+    'deps:Install project dependencies'
+    'exec:Run a command with JANET_PATH set'
+    'help:Show help text'
+    'install:Install the current project or a package'
+    'janet:Run janet with JANET_PATH set'
+    'list-installed:List installed packages'
+    'list-pkgs:List available packages'
+    'load-lockfile:Install packages from a lockfile'
+    'make-lockfile:Create a reproducible lockfile'
+    'new-c-project:Scaffold a new C+Janet project'
+    'new-exe-project:Scaffold a new executable project'
+    'new-project:Scaffold a new Janet project'
+    'quickbin:Create a standalone executable from a script'
+    'repl:Start a REPL with project env'
+    'rule-tree:Show the build rule dependency tree'
+    'rules:List all build rules'
+    'run:Run a specific build rule'
+    'save-config:Save current config to a file'
+    'show-config:Print current configuration'
+    'show-paths:Print install paths'
+    'tasks:List defined project tasks'
+    'test:Run project tests'
+    'uninstall:Uninstall the current project or a package'
+    'update-installed:Reinstall all installed packages'
+    'update-pkgs:Update the package listing'
+)
+
+local -a global_opts
+global_opts=(
+    '(-l --local)'{-l,--local}'[Use local tree ./jpm_tree]'
+    '(-v --verbose)'{-v,--verbose}'[Show verbose output]'
+    '--offline[Do not download remote repositories]'
+    '--silent[Suppress subprocess output]'
+    '--nocolor[Disable color in debug REPL]'
+    '--test[Enable testing when installing]'
+    '--update-pkgs[Update package listing before running]'
+    '--tree=[Use a custom tree directory]:directory:_files -/'
+    '--config-file=[Load settings from config file]:file:_files'
+    '--modpath=[Module installation directory]:directory:_files -/'
+    '--binpath=[Binary installation directory]:directory:_files -/'
+    '--headerpath=[Janet headers directory]:directory:_files -/'
+    '--optimize=[C/C++ optimization level]:level:(0 1 2 3)'
+    '--workers=[Number of parallel build workers]:count: '
+    '--build-type=[Build preset]:type:(release debug develop)'
+)
+
+_jpm() {
+    local state
+
+    _arguments -C \
+        $global_opts \
+        '1: :->subcommand' \
+        '*: :->args' \
+        && return 0
+
+    case $state in
+        subcommand)
+            _describe 'jpm subcommand' subcommands
+            ;;
+        args)
+            case $words[2] in
+                install)
+                    _files
+                    ;;
+                load-lockfile|make-lockfile)
+                    _files -g '*.jdn'
+                    ;;
+                new-project|new-c-project|new-exe-project)
+                    _message 'project name'
+                    ;;
+                run|rule-tree)
+                    local rules
+                    if rules=$(jpm rules 2>/dev/null); then
+                        _values 'rule' ${(f)rules}
+                    fi
+                    ;;
+            esac
+            ;;
+    esac
+}
+
+_jpm "$@"


### PR DESCRIPTION
## Summary

Adds a `completions/` directory with shell completion scripts for `jpm`
and `janet`, addressing janet-lang/janet#1567.

### jpm completions

All 31 subcommands are covered:

```
build  clean  configure  clear-cache  clear-manifest  debug-repl
deps   exec   help       install      janet            list-installed
list-pkgs  load-lockfile  make-lockfile  new-c-project  new-exe-project
new-project  quickbin  repl  rule-tree  rules  run  save-config
show-config  show-paths  tasks  test  uninstall  update-installed
update-pkgs
```

Global flags (`--local`, `--tree=`, `--verbose`, `--offline`, `--build-type=`,
`--optimize=`, `--workers=`, ...) complete before subcommands.

Context-aware completions for:
- `run` / `rule-tree` — offers rules from `jpm rules`
- `load-lockfile` / `make-lockfile` — completes `.jdn` files
- `new-project` / `new-c-project` / `new-exe-project` — completes directories

### janet completions

All CLI flags with argument hints (`-e`/`--eval`, `-m`/`--syspath`,
`-w`/`--lint-warn` with level choices, etc.). Default file completion
filtered to `.janet` and `.jimage`.

## Installation

See `completions/README.md` for per-shell install instructions (no root
required — all user-level paths).

## Test plan

- [ ] `jpm <Tab>` → lists subcommands
- [ ] `jpm --<Tab>` → lists global flags
- [ ] `jpm run <Tab>` → lists project rules (if project.janet present)
- [ ] `jpm load-lockfile <Tab>` → completes `.jdn` files
- [ ] `janet --lint-warn <Tab>` → offers `none normal strict`
- [ ] `janet <Tab>` → completes `.janet` / `.jimage` files